### PR TITLE
Typo fixes

### DIFF
--- a/BACKGROUND_MIGRATIONS.md
+++ b/BACKGROUND_MIGRATIONS.md
@@ -120,7 +120,7 @@ enqueue_background_migration("MyMigrationWithArgs", arg1, arg2, ...)
 * `CopyColumn` - copies data from one column(s) to other(s) (enqueue using `copy_column_in_background`)
 * `DeleteAssociatedRecords` - deletes records associated with a parent object (enqueue using `delete_associated_records_in_background`)
 * `DeleteOrphanedRecords` - deletes records with one or more missing relations (enqueue using `delete_orphaned_records_in_background`)
-* `PerformActionOnRelation` - performs specific action on a relation or indvidual records (enqueue using `perform_action_on_relation_in_background`)
+* `PerformActionOnRelation` - performs specific action on a relation or individual records (enqueue using `perform_action_on_relation_in_background`)
 * `ResetCounters` - resets one or more counter caches to their correct value (enqueue using `reset_counters_in_background`)
 
 ## Testing
@@ -240,7 +240,7 @@ Specify the throttle condition as a block:
 ```ruby
 # config/initializers/online_migrations.rb
 
-OnlineMigrations.config.backround_migrations.throttler = -> { DatabaseStatus.unhealthy? }
+OnlineMigrations.config.background_migrations.throttler = -> { DatabaseStatus.unhealthy? }
 ```
 
 Note that it's up to you to define a throttling condition that makes sense for your app. For example, you can check various PostgreSQL metrics such as replication lag, DB threads, whether DB writes are available, etc.
@@ -254,7 +254,7 @@ If you want to integrate with an exception monitoring service (e.g. Bugsnag), yo
 ```ruby
 # config/initializers/online_migrations.rb
 
-OnlineMigrations.config.backround_migrations.error_handler = ->(error, errored_job) do
+OnlineMigrations.config.background_migrations.error_handler = ->(error, errored_job) do
   Bugsnag.notify(error) do |notification|
     notification.add_metadata(:background_migration, { name: errored_job.migration_name })
   end

--- a/lib/generators/online_migrations/templates/initializer.rb.tt
+++ b/lib/generators/online_migrations/templates/initializer.rb.tt
@@ -38,7 +38,7 @@ OnlineMigrations.configure do |config|
   # migration failure in production. This is also useful in development to get
   # a better grasp of what is going on for high-level statements like add_column_with_default.
   #
-  # Note: It can be overriden by `ONLINE_MIGRATIONS_VERBOSE_SQL_LOGS` environment variable.
+  # Note: It can be overridden by `ONLINE_MIGRATIONS_VERBOSE_SQL_LOGS` environment variable.
   config.verbose_sql_logs = defined?(Rails) && Rails.env.production?
 
   # Lock retries.
@@ -67,25 +67,25 @@ OnlineMigrations.configure do |config|
 
   # ==> Background migrations configuration
   # The number of rows to process in a single background migration run.
-  # config.backround_migrations.batch_size = 20_000
+  # config.background_migrations.batch_size = 20_000
 
   # The smaller batches size that the batches will be divided into.
-  # config.backround_migrations.sub_batch_size = 1000
+  # config.background_migrations.sub_batch_size = 1000
 
   # The pause interval between each background migration job's execution (in seconds).
-  # config.backround_migrations.batch_pause = 0.seconds
+  # config.background_migrations.batch_pause = 0.seconds
 
   # The number of milliseconds to sleep between each sub_batch execution.
-  # config.backround_migrations.sub_batch_pause_ms = 100
+  # config.background_migrations.sub_batch_pause_ms = 100
 
   # Maximum number of batch run attempts.
   # When attempts are exhausted, the individual batch is marked as failed.
-  # config.backround_migrations.batch_max_attempts = 5
+  # config.background_migrations.batch_max_attempts = 5
 
   # Configure custom throttler for background migrations.
   # It will be called before each batch run.
   # If throttled, the current run will be retried next time.
-  # config.backround_migrations.throttler = -> { DatabaseStatus.unhealthy? }
+  # config.background_migrations.throttler = -> { DatabaseStatus.unhealthy? }
 
   # The number of seconds that must pass before the running job is considered stuck.
   # config.background_migrations.stuck_jobs_timeout = 1.hour
@@ -95,7 +95,7 @@ OnlineMigrations.configure do |config|
   config.background_migrations.backtrace_cleaner = Rails.backtrace_cleaner
 
   # The callback to perform when an error occurs in the migration job.
-  # config.backround_migrations.error_handler = ->(error, errored_job) do
+  # config.background_migrations.error_handler = ->(error, errored_job) do
   #   Bugsnag.notify(error) do |notification|
   #     notification.add_metadata(:background_migration, { name: errored_job.migration_name })
   #   end

--- a/lib/online_migrations/background_migrations/config.rb
+++ b/lib/online_migrations/background_migrations/config.rb
@@ -43,7 +43,7 @@ module OnlineMigrations
       # @return [Proc]
       #
       # @example
-      #   OnlineMigrations.config.backround_migrations.throttler = -> { DatabaseStatus.unhealthy? }
+      #   OnlineMigrations.config.background_migrations.throttler = -> { DatabaseStatus.unhealthy? }
       #
       attr_reader :throttler
 
@@ -64,7 +64,7 @@ module OnlineMigrations
       # The callback to perform when an error occurs in the migration job.
       #
       # @example
-      #   OnlineMigrations.config.backround_migrations.error_handler = ->(error, errored_job) do
+      #   OnlineMigrations.config.background_migrations.error_handler = ->(error, errored_job) do
       #     Bugsnag.notify(error) do |notification|
       #       notification.add_metadata(:background_migration, { name: errored_job.migration_name })
       #     end

--- a/lib/online_migrations/command_checker.rb
+++ b/lib/online_migrations/command_checker.rb
@@ -271,7 +271,7 @@ module OnlineMigrations
                 !options[:limit] || (existing_column.limit && options[:limit] >= existing_column.limit)
               end
             when :numeric, :decimal
-              # numeric and decimal are equivalent and can be used interchangably
+              # numeric and decimal are equivalent and can be used interchangeably
               [:numeric, :decimal].include?(existing_type) &&
               (
                 (

--- a/lib/online_migrations/config.rb
+++ b/lib/online_migrations/config.rb
@@ -153,7 +153,7 @@ module OnlineMigrations
     # This feature is enabled by default in a production Rails environment.
     # @return [Boolean]
     #
-    # @note: It can be overriden by `ONLINE_MIGRATIONS_VERBOSE_SQL_LOGS` environment variable.
+    # @note: It can be overridden by `ONLINE_MIGRATIONS_VERBOSE_SQL_LOGS` environment variable.
     #
     attr_accessor :verbose_sql_logs
 

--- a/test/command_checker/foreign_keys_test.rb
+++ b/test/command_checker/foreign_keys_test.rb
@@ -173,7 +173,7 @@ module CommandChecker
     class MultipleFksAndNewTables < TestMigration
       def change
         create_table :parents
-        create_table :childs do |t|
+        create_table :children do |t|
           t.belongs_to :parent, foreign_key: true # references new table
         end
 

--- a/test/schema_statements/changing_column_type_test.rb
+++ b/test/schema_statements/changing_column_type_test.rb
@@ -235,7 +235,7 @@ module SchemaStatements
       @connection.finalize_column_type_change(:projects, :id)
 
       project = Project.create!(description: "Description")
-      # We need to perform a direct SQL, since `_for_type_change` colums are ignored by SchemaCache.
+      # We need to perform a direct SQL, since `_for_type_change` columns are ignored by SchemaCache.
       old_id = @connection.select_value("SELECT id_for_type_change FROM projects WHERE id = #{project.id}").to_i
       assert_equal project.id, old_id
     end


### PR DESCRIPTION
I found a couple typos in the generated config file when I installed the gem, so in order to prevent people having problems with options that are not working due to a typo, I took a couple minutes to run my spellcheck tool and correct the found typos.