### PR TITLE
Mark CommandChecker#check with ruby2_keywords to make it compatible with Ruby 3.2

### DIFF
--- a/lib/online_migrations/command_checker.rb
+++ b/lib/online_migrations/command_checker.rb
@@ -42,6 +42,7 @@ module OnlineMigrations
 
       true
     end
+    ruby2_keywords(:check) if respond_to?(:ruby2_keywords, true)
 
     private
       def check_database_version


### PR DESCRIPTION
Started seeing errors like this in our migrations after upgrading to Ruby 3.2

```
wrong number of arguments (given 3, expected 2)
    .../online_migrations/lib/online_migrations/command_checker.rb:449:in `add_index'
    .../online_migrations/lib/online_migrations/command_checker.rb:119:in `do_check'
    .../online_migrations/lib/online_migrations/command_checker.rb:34:in `check'
    .../online_migrations/lib/online_migrations/migration.rb:21:in `method_missing'
```

It looks like Ruby 3.2 changed how methods that take a rest parameter (like `*args`) and delegate keyword arguments through `foo(*args)` work, and now they have to be marked with `ruby2_keywords`. So it looks like `CommandChecker#check` needed the `ruby2_keywords`.

`online_migrations` tests were failing when running locally with Ruby 3.2, not sure if worth configuring the CI to run with both Ruby 3.1 and 3.2

From the [release notes](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/):

> Methods taking a rest parameter (like *args) and wishing to delegate keyword arguments through foo(*args) must now be marked with ruby2_keywords (if not already the case). In other words, all methods wishing to delegate keyword arguments through *args must now be marked with ruby2_keywords, with no exception. This will make it easier to transition to other ways of delegation once a library can require Ruby 3+. Previously, the ruby2_keywords flag was kept if the receiving method took *args, but this was a bug and an inconsistency. A good technique to find potentially missing ruby2_keywords is to run the test suite, find the last method which must receive keyword arguments for each place where the test suite fails, and use puts nil, caller, nil there. Then check that each method/block on the call chain which must delegate keywords is correctly marked with ruby2_keywords. [[Bug #18625](https://bugs.ruby-lang.org/issues/18625)] [[Bug #16466](https://bugs.ruby-lang.org/issues/16466)]

```rb
  def target(**kw)
  end

  # Accidentally worked without ruby2_keywords in Ruby 2.7-3.1, ruby2_keywords
  # needed in 3.2+. Just like (*args, **kwargs) or (...) would be needed on
  # both #foo and #bar when migrating away from ruby2_keywords.
  ruby2_keywords def bar(*args)
    target(*args)
  end

  ruby2_keywords def foo(*args)
    bar(*args)
  end

  foo(k: 1)
```