### PR TITLE
Improvements to `initialize_column(s)_type_change`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master (unreleased)
 
+- Fix preserving old column options (`:comment` and `:collation`) when changing column type
+- Set `NOT NULL` during new column creation when changing column type for PostgreSQL >= 11
+
 ## 0.5.4 (2022-01-03)
 
 - Support ruby 3.2.0

--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ A safer approach can be accomplished in several steps:
   end
   ```
 
+**Note**: `initialize_column_type_change` accepts additional options (like `:limit`, `:default` etc)
+which will be passed to `add_column` when creating a new column, so you can override previous values.
+
 2. Backfill data from the old column to the new column:
 
   ```ruby

--- a/lib/online_migrations/error_messages.rb
+++ b/lib/online_migrations/error_messages.rb
@@ -176,6 +176,9 @@ A safer approach can be accomplished in several steps:
     end
   end
 
+**Note**: `initialize_column_type_change` accepts additional options (like `:limit`, `:default` etc)
+which will be passed to `add_column` when creating a new column, so you can override previous values.
+
 2. Backfill data from the old column to the new column:
 
   class Backfill<%= migration_name %> < <%= migration_parent %>

--- a/test/command_checker/change_column_test.rb
+++ b/test/command_checker/change_column_test.rb
@@ -43,6 +43,9 @@ module CommandChecker
             end
           end
 
+        **Note**: `initialize_column_type_change` accepts additional options (like `:limit`, `:default` etc)
+        which will be passed to `add_column` when creating a new column, so you can override previous values.
+
         2. Backfill data from the old column to the new column:
 
           class BackfillCommandChecker::ChangeColumnTest::ChangeColumnType < #{migration_parent_string}


### PR DESCRIPTION
Some hosted dbs e.g. Google cloud sql will not allow updates to internal tables e.g. pg_catalog

~~This change rescues, cancelling transaction and warning that not null check was not performed.~~

~~This change adds a check for pg >=12.  If 12 then add null constrain is safe if not use workaround per https://habr.com/ru/company/haulmont/blog/493954/~~

Set new col null to old col null by default when PG >= 12