### PR TITLE
Fix broken link in `background_migrations.md` docs

### DIFF
--- a/docs/background_migrations.md
+++ b/docs/background_migrations.md
@@ -84,7 +84,7 @@ end
 # ...
 ```
 
-`enqueue_background_migration` accepts additional configuration options which controls how the background migration is run. Check the [source code](https://github.com/fatkodima/online_migrations/blob/master/lib/online_migrations/background_migrations/online_migrations.rb) for the list of all available configuration options.
+`enqueue_background_migration` accepts additional configuration options which controls how the background migration is run. Check the [source code](https://github.com/fatkodima/online_migrations/blob/master/lib/online_migrations/background_migrations/migration_helpers.rb) for the list of all available configuration options.
 
 ## Custom Background Migration Arguments
 


### PR DESCRIPTION
Fixed a broken link in the documentation related to background migrations :unicorn: 