### PR TITLE
Promote check constraint to not null on PG >= 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
 
+- Promote check constraint to `NOT NULL` on PostgreSQL >= 12 when changing column type
 - Fix `safety_assured` with `revert`
 
 ## 0.8.1 (2023-08-04)

--- a/test/schema_statements/changing_column_type_test.rb
+++ b/test/schema_statements/changing_column_type_test.rb
@@ -263,16 +263,24 @@ module SchemaStatements
     def test_finalize_column_type_change_preserves_not_null_without_default_before_12
       with_postgres(11) do
         @connection.initialize_column_type_change(:projects, :description, :text)
-        @connection.finalize_column_type_change(:projects, :description)
-        refute column_for(:projects, :description).null
+
+        assert_sql("UPDATE pg_catalog.pg_attribute") do
+          @connection.finalize_column_type_change(:projects, :description)
+        end
+
+        assert_equal false, column_for(:projects, :description).null
       end
     end
 
     def test_finalize_column_type_change_preserves_not_null_without_default_after_12
       with_postgres(12) do
         @connection.initialize_column_type_change(:projects, :description, :text)
-        @connection.finalize_column_type_change(:projects, :description)
-        refute column_for(:projects, :description).null
+
+        refute_sql("UPDATE pg_catalog.pg_attribute") do
+          @connection.finalize_column_type_change(:projects, :description)
+        end
+
+        assert_equal false, column_for(:projects, :description).null
       end
     end
 

--- a/test/schema_statements/changing_column_type_test.rb
+++ b/test/schema_statements/changing_column_type_test.rb
@@ -260,6 +260,22 @@ module SchemaStatements
       end
     end
 
+    def test_finalize_column_type_change_preserves_not_null_without_default_before_12
+      with_postgres(11) do
+        @connection.initialize_column_type_change(:projects, :description, :text)
+        @connection.finalize_column_type_change(:projects, :description)
+        refute column_for(:projects, :description).null
+      end
+    end
+
+    def test_finalize_column_type_change_preserves_not_null_without_default_after_12
+      with_postgres(12) do
+        @connection.initialize_column_type_change(:projects, :description, :text)
+        @connection.finalize_column_type_change(:projects, :description)
+        refute column_for(:projects, :description).null
+      end
+    end
+
     def test_finalize_column_type_change_keeps_columns_in_sync
       @connection.initialize_column_type_change(:projects, :id, :bigint)
       @connection.finalize_column_type_change(:projects, :id)


### PR DESCRIPTION
Addresses #34 .

### References
* Mailing list discussion: [Feature idea: use index when checking for NULLs before SET NOT NULL](https://www.postgresql.org/message-id/flat/7fc87d44-82de-4592-9cca-14536af274c3%40www.fastmail.com).
* [Commit](https://github.com/postgres/postgres/commit/bbb96c3704c041d139181c6601e5bc770e045d26) introducing the feature to PostgreSQL.
* [SO answer](https://dba.stackexchange.com/a/268128) from author of commit above.
* [Recipe](https://gist.github.com/jjb/fab5cc5f0e1b23af28694db4fc01c55a), with links to further reading

### Note on author's minimal expertise :)
I'm not really qualified to evaluate any risks associated with this approach. I've read through the references above and done some minimal testing locally, but don't have much personal expertise in PostgreSQL.

As such, i'm relying on reviewers to weigh in on the approach and potential gotchas.