### PR TITLE
[Fix #47] `add_reference_concurrently` not checking for mismatching types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix `add_reference_concurrently` to check for mismatched key types
+
 ## 0.14.1 (2024-02-21)
 
 - Fix `MigrationRunner` to consider `run_background_migrations_inline` proc

--- a/lib/online_migrations/command_recorder.rb
+++ b/lib/online_migrations/command_recorder.rb
@@ -77,6 +77,10 @@ module OnlineMigrations
 
       include StraightReversions
 
+      def invert_add_reference_concurrently(args)
+        [:remove_reference, args]
+      end
+
       def invert_swap_column_names(args)
         table_name, column1, column2 = args
         [:swap_column_names, [table_name, column2, column1]]


### PR DESCRIPTION
Fixes https://github.com/fatkodima/online_migrations/issues/47

The issue was that `add_reference_concurrently` does not have its commands checked. I've now sent it through the same checked for `add_reference` while ensuring the bad index check always passes.