### PR TITLE
Update configuring docs

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -103,7 +103,7 @@ config.lock_retrier = OnlineMigrations::ExponentialLockRetrier.new(
 )
 ```
 
-When statement within transaction fails - the whole transaction is retried.
+When statement within transaction fails - the whole transaction is retried. Similarly if any statement fails when running outside a transaction then the whole migration is retried, e.g. using `disable_ddl_transaction!`.
 
 To permanently disable lock retries, you can set `lock_retrier` to `nil`.
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -107,9 +107,9 @@ When a statement within transaction fails - the whole transaction is retried. If
 
 To temporarily disable lock retries while running migrations, set `DISABLE_LOCK_RETRIES` env variable. This is useful when you are deploying a hotfix and do not want to wait too long while the lock retrier safely tries to acquire the lock, but try to acquire the lock immediately with the default configured lock timeout value.
 
-To permanently disable lock retries, you can set `lock_retrier` to `nil`, which [configures](https://github.com/fatkodima/online_migrations/blob/9cebfd00b870ab246e813d8109767ccaf10a7df6/lib/online_migrations/config.rb#L219) the `NullLockRetrier`. Please note that under this LockRetrier your migrations will be run with a [lock_timeout of 0](https://github.com/fatkodima/online_migrations/blob/9cebfd00b870ab246e813d8109767ccaf10a7df6/lib/online_migrations/lock_retrier.rb#L232) which doesn't enforce a lock timeout.
+To permanently disable lock retries, you can set `lock_retrier` to `nil`.
 
-Finally, if your LockRetrier implementation does not have a explicit `lock_timeout` value configured then the timeout behaviour will fallback to the database configuration (`config/database.yml`) or the postgresql sever config value ([off by default](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT)). Please take care configuring this value as this fallback may result in your migrations running without a lock timeout!
+Finally, if your lock retrier implementation does not have an explicit `lock_timeout` value configured, then the timeout behavior will fallback to the database configuration (`config/database.yml`) or the PostgreSQL server config value ([off by default](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT)). Take care configuring this value, as this fallback may result in your migrations running without a lock timeout!
 
 ## Existing Migrations
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -69,7 +69,6 @@ config.statement_timeout = 1.hour
 
 and a lock timeout for migrations can be configured via the `lock_retrier`.
 
-**Note**: If you do not set a lock retrier the default `NullLockRetrier` is used and it has a `lock_timeout` value of `0` that [disables the timeout](https://www.postgresql.org/docs/16/runtime-config-client.html#GUC-LOCK-TIMEOUT).
 
 Or set the timeouts directly on the database user that runs migrations:
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -69,6 +69,8 @@ config.statement_timeout = 1.hour
 
 and a lock timeout for migrations can be configured via the `lock_retrier`.
 
+**Note**: If you do not set a lock retrier the default `NullLockRetrier` is used and it has a `lock_timeout` value of `0` that [disables the timeout](https://www.postgresql.org/docs/16/runtime-config-client.html#GUC-LOCK-TIMEOUT).
+
 Or set the timeouts directly on the database user that runs migrations:
 
 ```sql

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -103,7 +103,7 @@ config.lock_retrier = OnlineMigrations::ExponentialLockRetrier.new(
 )
 ```
 
-When statement within transaction fails - the whole transaction is retried. Similarly if any statement fails when running outside a transaction then the whole migration is retried, e.g. using `disable_ddl_transaction!`.
+When statement within transaction fails - the whole transaction is retried. If any statement fails when running outside a transaction (e.g. using `disable_ddl_transaction!`) then only that statement is retried.
 
 To permanently disable lock retries, you can set `lock_retrier` to `nil`.
 


### PR DESCRIPTION
Closes #50 

This PR adds clarifying wording to `docs/configuring.md`. Specifically about how 
- the lock retrier works when the migration runs without a transaction, e.g. using `disable_ddl_transaction!`
- the default behaviour of `NullLockRetrier` specifies a `lock_timeout` of 0 and thus disables the timeout

Happy to iterate on this wording where you think appropriate.