### PR TITLE
Idempotency bugs in `add_reference_concurrently`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
 
+- Fix `add_reference_concurrently` to be idempotent when adding a foreign key
 - Fix `enqueue_background_data_migration` to be idempotent
 
 ## 0.19.1 (2024-05-24)

--- a/lib/online_migrations/schema_statements.rb
+++ b/lib/online_migrations/schema_statements.rb
@@ -773,7 +773,8 @@ module OnlineMigrations
     # @see https://edgeapi.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
     #
     def add_foreign_key(from_table, to_table, **options)
-      if foreign_key_exists?(from_table, to_table, **options)
+      # Do not consider validation for idempotency.
+      if foreign_key_exists?(from_table, to_table, **options.except(:validate))
         message = +"Foreign key was not created because it already exists " \
                    "(this can be due to an aborted migration or similar): from_table: #{from_table}, to_table: #{to_table}"
         message << ", #{options.inspect}" if options.any?

--- a/test/command_checker/add_reference_test.rb
+++ b/test/command_checker/add_reference_test.rb
@@ -138,6 +138,30 @@ module CommandChecker
       assert_safe AddReferenceForeignKeyNoValidate
     end
 
+    def test_add_reference_foreign_key_no_validate_is_not_idempotent
+      assert_empty @connection.foreign_keys(:projects)
+
+      migrate AddReferenceForeignKeyNoValidate
+      assert_raises_with_message(StandardError, /column "user_id" of relation "projects" already exists/) do
+        migrate AddReferenceForeignKeyNoValidate
+      end
+    ensure
+      migrate AddReferenceForeignKeyNoValidate, direction: :down
+      assert_empty @connection.foreign_keys(:projects)
+    end
+
+    class AddReferenceForeignKeyNoValidatePluralizeName < TestMigration
+      disable_ddl_transaction!
+
+      def change
+        add_reference :projects, :users, index: false, foreign_key: { validate: false }
+      end
+    end
+
+    def test_add_reference_foreign_key_no_validate_with_pluralized_table_name
+      assert_safe AddReferenceForeignKeyNoValidatePluralizeName
+    end
+
     class AddReferenceForeignKeyValidate < TestMigration
       def change
         add_reference :projects, :user, index: false, foreign_key: { validate: true }

--- a/test/command_checker/add_reference_test.rb
+++ b/test/command_checker/add_reference_test.rb
@@ -138,18 +138,6 @@ module CommandChecker
       assert_safe AddReferenceForeignKeyNoValidate
     end
 
-    def test_add_reference_foreign_key_no_validate_is_not_idempotent
-      assert_empty @connection.foreign_keys(:projects)
-
-      migrate AddReferenceForeignKeyNoValidate
-      assert_raises_with_message(StandardError, /column "user_id" of relation "projects" already exists/) do
-        migrate AddReferenceForeignKeyNoValidate
-      end
-    ensure
-      migrate AddReferenceForeignKeyNoValidate, direction: :down
-      assert_empty @connection.foreign_keys(:projects)
-    end
-
     class AddReferenceForeignKeyNoValidatePluralizeName < TestMigration
       disable_ddl_transaction!
 

--- a/test/command_checker/foreign_keys_test.rb
+++ b/test/command_checker/foreign_keys_test.rb
@@ -69,6 +69,31 @@ module CommandChecker
       assert_safe AddForeignKeyNoValidate
     end
 
+    def test_add_foreign_key_no_validate_is_idempotent
+      assert_empty @connection.foreign_keys(:projects)
+
+      migrate AddForeignKeyNoValidate
+      migrate AddForeignKeyNoValidate
+      migrate AddForeignKeyNoValidate
+      
+      assert_equal 1, @connection.foreign_keys(:projects).size
+    ensure
+      migrate AddForeignKeyNoValidate, direction: :down
+      assert_empty @connection.foreign_keys(:projects)
+    end
+
+    class AddForeignKeySingularToTable < TestMigration
+      def change
+        add_foreign_key :projects, :user, validate: false
+      end
+    end
+
+    def test_add_foreign_key_no_validate
+      assert_raises_with_message(StandardError, /PG::UndefinedTable: ERROR:  relation "user" does not exist/i) do
+        assert_safe AddForeignKeySingularToTable
+      end
+    end
+
     class AddForeignKeyFromNewTable < TestMigration
       def change
         create_table :posts_new do |t|

--- a/test/command_checker/foreign_keys_test.rb
+++ b/test/command_checker/foreign_keys_test.rb
@@ -74,24 +74,8 @@ module CommandChecker
 
       migrate AddForeignKeyNoValidate
       migrate AddForeignKeyNoValidate
-      migrate AddForeignKeyNoValidate
-      
+
       assert_equal 1, @connection.foreign_keys(:projects).size
-    ensure
-      migrate AddForeignKeyNoValidate, direction: :down
-      assert_empty @connection.foreign_keys(:projects)
-    end
-
-    class AddForeignKeySingularToTable < TestMigration
-      def change
-        add_foreign_key :projects, :user, validate: false
-      end
-    end
-
-    def test_add_foreign_key_no_validate
-      assert_raises_with_message(StandardError, /PG::UndefinedTable: ERROR:  relation "user" does not exist/i) do
-        assert_safe AddForeignKeySingularToTable
-      end
     end
 
     class AddForeignKeyFromNewTable < TestMigration

--- a/test/schema_statements/add_reference_concurrently_test.rb
+++ b/test/schema_statements/add_reference_concurrently_test.rb
@@ -76,7 +76,6 @@ module SchemaStatements
 
       connection.add_reference_concurrently :milestones, :project, foreign_key: true
       connection.add_reference_concurrently :milestones, :project, foreign_key: true
-      connection.add_reference_concurrently :milestones, :project, foreign_key: true
 
       assert_equal 1, connection.foreign_keys(:milestones).size
     end


### PR DESCRIPTION
The adding of foreign keys in `add_reference_concurrently` is not idempotent. Instead of being safely skipped [here](https://github.com/fatkodima/online_migrations/blob/db786eedf2e3225b4fb1afad827550537f2fc738/lib/online_migrations/schema_statements.rb#L777), an error is raised.

The root cause is the merging in of `validate: false` [here](https://github.com/fatkodima/online_migrations/blob/db786eedf2e3225b4fb1afad827550537f2fc738/lib/online_migrations/schema_statements.rb#L672C98-L672C113). That gets passed through to the check [here](https://github.com/rails/rails/blob/770b35389610bc15bc83d20a199566acb6a1c22a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L164). It means that if you use `add_reference_concurrently` to create a **validated** foreign key, and then call `add_reference_concurrently` again, it will always raise, because the matching foreign key won't be found.

I'm not sure what the right approach to fixing this is yet but I wanted to add some failing tests to demonstrate the issue.