### PR TITLE
Fix add_reference_concurrently adding type for non-polymorphic ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
 
+- Fix `add_refernce_concurrently` when adding non polymorphic references
 - Fix progress for background migrations with small number of records
 
 ## 0.19.5 (2024-09-20)

--- a/lib/online_migrations/schema_statements.rb
+++ b/lib/online_migrations/schema_statements.rb
@@ -655,7 +655,7 @@ module OnlineMigrations
         add_column(table_name, column_name, type, null: allow_null)
       end
 
-      if !column_exists?(table_name, type_column_name)
+      if options[:polymorphic] && !column_exists?(table_name, type_column_name)
         allow_null = options[:polymorphic].is_a?(Hash) ? options[:polymorphic][:null] : true
         add_column(table_name, type_column_name, :string, null: allow_null)
       end

--- a/test/schema_statements/add_reference_concurrently_test.rb
+++ b/test/schema_statements/add_reference_concurrently_test.rb
@@ -32,6 +32,7 @@ module SchemaStatements
 
       Milestone.reset_column_information
       assert_includes Milestone.column_names, "project_id"
+      assert_not_includes Milestone.column_names, "project_type"
     end
 
     def test_add_reference_concurrently_adds_index


### PR DESCRIPTION
After this fix https://github.com/fatkodima/online_migrations/commit/69b79ce00473e3c105330e5845d0904ee2421256
 I ran into an issue where `add_reference_concurrently` added a `_type` column without the polymorphic option set. 