### PR TITLE
Add schema statement command to lock retrier

### DIFF
--- a/lib/online_migrations/lock_retrier.rb
+++ b/lib/online_migrations/lock_retrier.rb
@@ -56,7 +56,7 @@ module OnlineMigrations
     #
     # @param _attempt [Integer] attempt number
     #
-    def lock_timeout(_attempt); end
+    def lock_timeout(_attempt, command: nil, arguments: nil); end
 
     # Returns sleep time after unsuccessful lock attempt (in seconds)
     #
@@ -206,7 +206,6 @@ module OnlineMigrations
     # @see LockRetrier#lock_timeout
     #
     def lock_timeout(_attempt, command: nil, arguments: nil)
-      # binding.irb
       @lock_timeout
     end
 

--- a/lib/online_migrations/lock_retrier.rb
+++ b/lib/online_migrations/lock_retrier.rb
@@ -77,7 +77,7 @@ module OnlineMigrations
     #     add_column(:users, :name, :string)
     #   end
     #
-    def with_lock_retries(connection, &block)
+    def with_lock_retries(connection, command = nil, *args, &block)
       return yield if lock_retries_disabled?
 
       current_attempt = 0
@@ -85,7 +85,7 @@ module OnlineMigrations
       begin
         current_attempt += 1
 
-        current_lock_timeout = lock_timeout(current_attempt)
+        current_lock_timeout = lock_timeout(current_attempt, command: command, arguments: args)
         if current_lock_timeout
           with_lock_timeout(connection, current_lock_timeout.in_milliseconds, &block)
         else
@@ -152,7 +152,8 @@ module OnlineMigrations
     # @return [Numeric] Database lock timeout value (in seconds)
     # @see LockRetrier#lock_timeout
     #
-    def lock_timeout(_attempt)
+    # def lock_timeout(_attempt)
+    def lock_timeout(_attempt, command: nil, arguments: nil)
       @lock_timeout
     end
 
@@ -204,7 +205,8 @@ module OnlineMigrations
     # @return [Numeric] Database lock timeout value (in seconds)
     # @see LockRetrier#lock_timeout
     #
-    def lock_timeout(_attempt)
+    def lock_timeout(_attempt, command: nil, arguments: nil)
+      # binding.irb
       @lock_timeout
     end
 

--- a/lib/online_migrations/migration.rb
+++ b/lib/online_migrations/migration.rb
@@ -21,6 +21,7 @@ module OnlineMigrations
         super
       elsif command_checker.check(method, *args, &block)
         if in_transaction?
+          # why doesn't this use the lock_retries block?
           super(method, *args)
         elsif method == :with_lock_retries
           connection.with_lock_retries(method, *args, &block)

--- a/lib/online_migrations/migration.rb
+++ b/lib/online_migrations/migration.rb
@@ -21,11 +21,11 @@ module OnlineMigrations
         super
       elsif command_checker.check(method, *args, &block)
         if in_transaction?
-          super
+          super(method, *args)
         elsif method == :with_lock_retries
-          connection.with_lock_retries(*args, &block)
+          connection.with_lock_retries(method, *args, &block)
         else
-          connection.with_lock_retries { super }
+          connection.with_lock_retries(method, *args) { super }
         end
       end
     end

--- a/lib/online_migrations/migrator.rb
+++ b/lib/online_migrations/migrator.rb
@@ -12,6 +12,12 @@ module OnlineMigrations
         end
 
       if use_transaction?(migration)
+        # why do we wrap the transaction in a lock_retries block here?
+        # we aren't running the schema statements yet, so we don't know the migration schema_statement command
+        #
+        # it appers that there are multiple entry points to the lock_retries behaviours
+        # one here and one via the method_missing in the migration.rb where we run the schema_statments
+        # I'm unsure why this is setup this way, thoughts appreciated.
         migration.connection.with_lock_retries do
           super
         end

--- a/lib/online_migrations/schema_statements.rb
+++ b/lib/online_migrations/schema_statements.rb
@@ -915,8 +915,6 @@ module OnlineMigrations
       __ensure_not_in_transaction!
 
       retrier = OnlineMigrations.config.lock_retrier
-
-      # how do we know the method at the call site? via the connection class we prepend this to?
       retrier.with_lock_retries(self, command, *args, &block)
     end
 

--- a/lib/online_migrations/schema_statements.rb
+++ b/lib/online_migrations/schema_statements.rb
@@ -911,11 +911,13 @@ module OnlineMigrations
     # Executes the block with a retry mechanism that alters the `lock_timeout`
     # and sleep time between attempts.
     #
-    def with_lock_retries(&block)
+    def with_lock_retries(command = nil, *args, &block)
       __ensure_not_in_transaction!
 
       retrier = OnlineMigrations.config.lock_retrier
-      retrier.with_lock_retries(self, &block)
+
+      # how do we know the method at the call site? via the connection class we prepend this to?
+      retrier.with_lock_retries(self, command, *args, &block)
     end
 
     private

--- a/test/lock_retrier_test.rb
+++ b/test/lock_retrier_test.rb
@@ -89,15 +89,6 @@ class LockRetrierTest < Minitest::Test
       OnlineMigrations.config.lock_retrier = previous
     end
 
-    # def with_dynamic_lock_retries
-    #   previous = OnlineMigrations.config.lock_retrier
-    #   OnlineMigrations.config.lock_retrier = OnlineMigrations::ConstantLockRetrier.new(attempts: 2, delay: 0, lock_timeout: 0.001)
-
-    #   yield
-    # ensure
-    #   OnlineMigrations.config.lock_retrier = previous
-    # end
-
     def assert_lock_timeout(&block)
       error = assert_raises(&block)
       assert_match(/canceling statement due to lock timeout/, error.message)

--- a/test/lock_retrier_test.rb
+++ b/test/lock_retrier_test.rb
@@ -80,9 +80,9 @@ class LockRetrierTest < Minitest::Test
       ActiveRecord::Base.connection_pool.checkin(connection) if connection
     end
 
-    def with_lock_retries(lock_retrier = OnlineMigrations::ConstantLockRetrier.new(attempts: 2, delay: 0, lock_timeout: 0.001))
+    def with_lock_retries
       previous = OnlineMigrations.config.lock_retrier
-      OnlineMigrations.config.lock_retrier = lock_retrier
+      OnlineMigrations.config.lock_retrier = OnlineMigrations::ConstantLockRetrier.new(attempts: 2, delay: 0, lock_timeout: 0.001)
 
       yield
     ensure

--- a/test/lock_retrier_test.rb
+++ b/test/lock_retrier_test.rb
@@ -32,6 +32,7 @@ class LockRetrierTest < Minitest::Test
   def test_with_retries
     with_table_locked(:users) do
       with_lock_retries do
+        # this doesn't pass the command to the lock_retrier.lock_timeout method - why?
         assert_lock_timeout { migrate(LockRetriesMigration) }
       end
     end
@@ -42,12 +43,29 @@ class LockRetrierTest < Minitest::Test
   def test_with_retries_no_transaction
     with_table_locked(:users) do
       with_lock_retries do
+        # this does pass the command to the lock_retrier.lock_timeout method
         assert_lock_timeout { migrate(LockRetriesNoTransactionMigration) }
       end
     end
 
     # Initial run only, then just `add_column` is retried
     assert_equal 1, $migrate_attempts
+  end
+
+  def test_lock_timeout_accepts_command_parameter
+    retrier = OnlineMigrations::ConstantLockRetrier.new(
+      attempts: 1,
+      delay: 0,
+      lock_timeout: 0.001
+    )
+
+    # Verify the method accepts both attempt and command parameters
+    assert_nothing_raised do
+      retrier.lock_timeout(1, command: "ALTER TABLE", arguments: ["users"])
+    end
+
+    # Verify it returns the expected lock_timeout value
+    assert_in_delta(0.001, retrier.lock_timeout(1, command: "ALTER TABLE", arguments: ["users"]))
   end
 
   private
@@ -62,14 +80,23 @@ class LockRetrierTest < Minitest::Test
       ActiveRecord::Base.connection_pool.checkin(connection) if connection
     end
 
-    def with_lock_retries
+    def with_lock_retries(lock_retrier = OnlineMigrations::ConstantLockRetrier.new(attempts: 2, delay: 0, lock_timeout: 0.001))
       previous = OnlineMigrations.config.lock_retrier
-      OnlineMigrations.config.lock_retrier = OnlineMigrations::ConstantLockRetrier.new(attempts: 2, delay: 0, lock_timeout: 0.001)
+      OnlineMigrations.config.lock_retrier = lock_retrier
 
       yield
     ensure
       OnlineMigrations.config.lock_retrier = previous
     end
+
+    # def with_dynamic_lock_retries
+    #   previous = OnlineMigrations.config.lock_retrier
+    #   OnlineMigrations.config.lock_retrier = OnlineMigrations::ConstantLockRetrier.new(attempts: 2, delay: 0, lock_timeout: 0.001)
+
+    #   yield
+    # ensure
+    #   OnlineMigrations.config.lock_retrier = previous
+    # end
 
     def assert_lock_timeout(&block)
       error = assert_raises(&block)


### PR DESCRIPTION
Towards #67 

Passes the schema statement migration command to the lock retrier. This allows the lock retrier to reflect on the command and determine a the timeout to be used.