### PR TITLE
Support schema qualified table names in column rename

### DIFF
--- a/lib/online_migrations/schema_cache.rb
+++ b/lib/online_migrations/schema_cache.rb
@@ -147,12 +147,8 @@ module OnlineMigrations
           schema, base_table_name = table_name.split('.')
 
           pool.with_connection do |connection|
-            default_schema_search_path = connection.schema_search_path
-            begin
-              connection.schema_search_path = schema
+            connection.with(schema_search_path: schema) do
               connection.views.include?(base_table_name)
-            ensure
-              connection.schema_search_path = default_schema_search_path
             end
           end
         else


### PR DESCRIPTION
Closes #72 

Updated the `OnlineMigrations::SchemaCache72.renamed_column?` method to check if the model table name is schema qualified, and accordingly set the schema search path.