### PR TITLE
Fix `OnlineMigrations::NullLockRetrier#with_lock_retries` method signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix `NullLockRetrier#with_lock_retries` method signature
+
 ## 0.30.0 (2025-10-17)
 
 - Fix `remove_check_constraint` when using `:if_exists`

--- a/lib/online_migrations/lock_retrier.rb
+++ b/lib/online_migrations/lock_retrier.rb
@@ -251,7 +251,7 @@ module OnlineMigrations
     def delay(_attempt, _command = nil, _arguments = [])
     end
 
-    def with_lock_retries(_connection)
+    def with_lock_retries(_connection, _command = nil, *_arguments)
       yield
     end
   end


### PR DESCRIPTION
After upgrading `online_migrations` to version 0.30.0 we've noticed that the `OnlineMigrations::NullLockRetrier` stopped working with an error similar to this:

```
An error has occurred, all later migrations canceled:

wrong number of arguments (given 5, expected 1)
```

Apparently the relevant change in behaviour was introduced on #68.

This PR addresses that and also includes missing tests for the `OnlineMigrations::NullLockRetrier` implementation.