### PR TITLE
Fix copying partial indexes when changing column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix copying partial indexes when changing column type
+
 ## 0.32.0 (2026-01-07)
 
 - Add ability to create delayed background migrations

--- a/lib/online_migrations/change_column_type_helpers.rb
+++ b/lib/online_migrations/change_column_type_helpers.rb
@@ -436,7 +436,10 @@ module OnlineMigrations
           }
 
           options[:using] = index.using if index.using
-          options[:where] = index.where if index.where
+
+          if index.where
+            options[:where] = index.where.gsub(/\b#{from_column}\b/, to_column)
+          end
 
           if index.opclasses.present?
             opclasses = index.opclasses.dup


### PR DESCRIPTION
Hello, I'm attempting to change a column type on a column that has an index with a where clause and it appears that the where clause is incorrectly updated during `finalize_column_type_change`. This PR diff has a failing test illustrating the issue. From what I can tell it's happening inside rails' `rename_column` which is called from `swap_column_names` [here](https://github.com/fatkodima/online_migrations/blob/dde452d8ec9445e73ec775ac2f968e33e37d0036/lib/online_migrations/change_column_type_helpers.rb#L293), so this may be an issue in rails instead of online_migrations. If you're familiar with the issue any insights would be appreciated.

Here is a sample print out from running the tests and inspecting the resulting indexes, the issue I'm seeing is that the column in the where clause is being renamed to the temp column for the name change:
```
[#<ActiveRecord::ConnectionAdapters::IndexDefinition:0x00000001235178a8
  @columns=["global_name"],
  @comment=nil,
  @include=nil,
  @lengths={},
  @name="index_projects_on_global_name",
  @nulls_not_distinct=false,
  @opclasses={},
  @orders={},
  @table=:projects,
  @type=nil,
  @unique=true,
  @using=:btree,
  @valid=true,
  @where="(global_name_for_type_change IS NOT NULL)">,       <---- this where clause should be "global_name IS NOT NULL"
 #<ActiveRecord::ConnectionAdapters::IndexDefinition:0x0000000123517308
  @columns=["global_name_for_type_change"],
  @comment=nil,
  @include=nil,
  @lengths={},
  @name="index_projects_on_global_name_for_type_change",
  @nulls_not_distinct=false,
  @opclasses={},
  @orders={},
  @table=:projects,
  @type=nil,
  @unique=true,
  @using=:btree,
  @valid=true,
  @where="(global_name_for_type_change IS NOT NULL)">,
...
```