### PR TITLE
Allow running to enqueued state transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Allow "running" to "enqueued" state transition for stuck background data migrations
+
 ## 0.33.0 (2026-02-04)
 
 - Change background migrations default status to "pending"

--- a/lib/online_migrations/background_data_migrations/migration_status_validator.rb
+++ b/lib/online_migrations/background_data_migrations/migration_status_validator.rb
@@ -13,12 +13,14 @@ module OnlineMigrations
         # enqueued -> failed occurs when the migration job fails to be enqueued, or
         #   if the migration is deleted before is starts running.
         "enqueued" => ["running", "paused", "cancelled", "failed"],
+        # running -> enqueued occurs when the migration is stuck and rescheduled by the scheduler.
         # running -> succeeded occurs when the migration completes successfully.
         # running -> pausing occurs when a user pauses the migration as it's performing.
         # running -> cancelling occurs when a user cancels the migration as it's performing.
         # running -> errored occurs when the migration raised an error during the last run.
         # running -> failed occurs when the migration raises an error when running and retry attempts exceeded.
         "running" => [
+          "enqueued",
           "succeeded",
           "pausing",
           "cancelling",

--- a/test/background_data_migrations/migration_test.rb
+++ b/test/background_data_migrations/migration_test.rb
@@ -48,7 +48,7 @@ module BackgroundDataMigrations
       assert_equal "MakeAllNonAdmins", m.migration_name
     end
 
-    def test_progress_succeded_migration
+    def test_progress_succeeded_migration
       m = build_migration(status: :succeeded)
       assert_in_delta 100.0, m.progress
     end


### PR DESCRIPTION
The last release made it possible for running migrations to be considered stuck, and to be rescheduled by the scheduler (commit https://github.com/fatkodima/online_migrations/commit/aec41282979de23f5acf29e4c8d27cba35264163). However, this causes an invalid state transition.