### PR TITLE
Fix validate_foreign_key in add_reference_concurrently when multiple FKs target same table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## master (unreleased)
+- Fix validating foreign key in `add_reference_concurrently` when multiple foreign keys target the same table
 
 ## 0.33.2 (2026-03-16)
 

--- a/lib/online_migrations/schema_statements.rb
+++ b/lib/online_migrations/schema_statements.rb
@@ -705,7 +705,7 @@ module OnlineMigrations
         add_foreign_key(table_name, foreign_table_name, **foreign_key, column: column_name, validate: false)
 
         if foreign_key[:validate] != false
-          validate_foreign_key(table_name, foreign_table_name, **foreign_key)
+          validate_foreign_key(table_name, foreign_table_name, **foreign_key, column: column_name)
         end
       end
     end

--- a/test/schema_statements/add_reference_concurrently_test.rb
+++ b/test/schema_statements/add_reference_concurrently_test.rb
@@ -115,6 +115,17 @@ module SchemaStatements
       assert_equal 2, connection.foreign_keys(:milestones).size
     end
 
+    def test_add_reference_concurrently_validates_correct_foreign_key_when_multiple_reference_same_table
+      connection.add_reference_concurrently :milestones, :project, foreign_key: true
+      connection.add_reference_concurrently :milestones, :root_project, foreign_key: { to_table: :projects }
+
+      foreign_keys = connection.foreign_keys(:milestones)
+      assert_equal 2, foreign_keys.size
+      foreign_keys.each do |fk|
+        assert fk.validated?, "Expected foreign key on #{fk.column} to be validated"
+      end
+    end
+
     def test_polymorphic_add_reference_concurrently
       connection.create_table(:images)
       connection.add_reference_concurrently(:images, :imageable, polymorphic: true, index: true)


### PR DESCRIPTION
Fixes #88

## Problem

`add_reference_concurrently` does not pass `column:` to `validate_foreign_key`. When a table has multiple foreign keys to the same target table, `validate_foreign_key` matches the first FK it finds, leaving the intended one unvalidated.

## Fix

One-line change: pass `column: column_name` to `validate_foreign_key`, consistent with:
- The `add_foreign_key` call two lines above (which already passes `column: column_name`)
- The `__copy_foreign_key` private method (which passes `column: to_column`)

## Test

Added a new test that creates two references to the same target table and verifies both FKs are validated. I kept this as a separate test method rather than adding assertions to the existing `test_add_reference_concurrently_when_already_references_target_table_via_foreign_key` to keep the diff minimal — happy to fold it into the existing test if preferred.