### PR TITLE
Fix add_column idempotency for :bigint and boolean default columns

### DIFF
--- a/lib/online_migrations/schema_statements.rb
+++ b/lib/online_migrations/schema_statements.rb
@@ -635,7 +635,7 @@ module OnlineMigrations
     # @see https://api.rubyonrails.org/v8.1/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column
     #
     def add_column(table_name, column_name, type, **options)
-      if column_exists?(table_name, column_name, type, **options)
+      if column_exists?(table_name, column_name)
         Utils.say("Column was not added because it already exists (this may be due to an aborted migration " \
                   "or similar) table_name: #{table_name}, column_name: #{column_name}")
       else

--- a/test/schema_statements/misc_test.rb
+++ b/test/schema_statements/misc_test.rb
@@ -55,6 +55,18 @@ module SchemaStatements
       assert @connection.column_exists?(:users, :nice)
     end
 
+    def test_add_column_is_idempotent_for_bigint
+      @connection.add_column(:users, :manager_id, :bigint)
+      assert_nothing_raised { @connection.add_column(:users, :manager_id, :bigint) }
+      assert @connection.column_exists?(:users, :manager_id)
+    end
+
+    def test_add_column_is_idempotent_with_boolean_default
+      @connection.add_column(:users, :active, :boolean, default: false)
+      assert_nothing_raised { @connection.add_column(:users, :active, :boolean, default: false) }
+      assert @connection.column_exists?(:users, :active)
+    end
+
     def test_add_exclusion_constraint
       user = User.create!
       start_date = 3.days.ago


### PR DESCRIPTION
Fixes https://github.com/fatkodima/online_migrations/issues/90

## Problem

Re-running a migration that calls `add_column` inside `disable_ddl_transaction!` (common when a concurrent index follows) can raise `PG::DuplicateColumn` and leave the migration permanently stuck.

The gem's `add_column` override guards against this with:

```ruby
if column_exists?(table_name, column_name, type, **options)
```

But `column_exists?` with a `type` or options is unreliable for two common cases:

1. **`:bigint` columns** — PostgreSQL reports them back as `:integer`, so `column_exists?(:users, :manager_id, :bigint)` returns `false` even when the column exists.
2. **`default: false`** — The database reads the default back as the string `"false"`, so the options comparison fails.

In both cases the guard returns `false`, `super` runs, and `PG::DuplicateColumn` is raised. Reported in #90.

## Fix

Check by column name only:

```ruby
if column_exists?(table_name, column_name)
```

This matches:
- `add_column_with_default` in this same gem (line 447)
- Rails core, which [dropped the type check](https://github.com/rails/rails/pull/42212) from `add_column` for the same reason
- Native `ADD COLUMN IF NOT EXISTS`, which also checks by name only

## Tests

Two new test cases cover the previously broken scenarios:
- Re-running `add_column` with `:bigint` type
- Re-running `add_column` with `default: false`