### PR TITLE
Make replace_index check independent of live database state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master (unreleased)
 
 - Drop support for Ruby < 3.3
+- Make "replacing an index" check independent of the live database state
 
 ## 0.34.0 (2026-05-29)
 

--- a/lib/online_migrations/command_checker.rb
+++ b/lib/online_migrations/command_checker.rb
@@ -573,13 +573,21 @@ module OnlineMigrations
             Array(index.columns).map(&:to_s) == Array(options[:column]).map(&:to_s)
         end
 
-        if index_def
-          existing_options = [:name, :columns, :unique, :where, :type, :using, :opclasses].filter_map do |option|
-            [option, index_def.public_send(option)]
-          end.to_h
+        # IndexDefinition expects "columns", but "remove_index" API uses "column".
+        options[:columns] = options[:column]
 
-          @removed_indexes << IndexDefinition.new(table: table_name, **existing_options)
-        end
+        # Fall back to the declared options when the index isn't present in the database,
+        # so an index remove → add is still recorded and caught.
+        existing_options =
+          [:name, :columns, :unique, :where, :type, :using, :opclasses].index_with do |option|
+            if index_def
+              index_def.public_send(option)
+            else
+              options[option]
+            end
+          end.compact
+
+        @removed_indexes << IndexDefinition.new(table: table_name, **existing_options)
       end
 
       def add_foreign_key(from_table, to_table, **options)

--- a/lib/online_migrations/index_definition.rb
+++ b/lib/online_migrations/index_definition.rb
@@ -3,10 +3,11 @@
 module OnlineMigrations
   # @private
   class IndexDefinition
-    attr_reader :table, :columns, :unique, :opclasses, :where, :type, :using
+    attr_reader :table, :name, :columns, :unique, :opclasses, :where, :type, :using
 
     def initialize(**options)
-      @table = options[:table]
+      @table = options[:table]&.to_s
+      @name = options[:name]&.to_s
       @columns = Array(options[:columns]).map(&:to_s)
       @unique = options[:unique]
       @opclasses = options[:opclass] || {}
@@ -20,7 +21,7 @@ module OnlineMigrations
       # For ActiveRecord::ConnectionAdapters::IndexDefinition is for expression indexes,
       # `columns` is a string
       table == other.table &&
-        columns.intersect?(Array(other.columns))
+        ((name && name == other.name) || columns.intersect?(Array(other.columns)))
     end
 
     # @param other [OnlineMigrations::IndexDefinition, ActiveRecord::ConnectionAdapters::IndexDefinition]

--- a/test/command_checker/indexes_test.rb
+++ b/test/command_checker/indexes_test.rb
@@ -226,5 +226,18 @@ module CommandChecker
 
       assert_unsafe ReplaceIndexAlmostCoveringIndexExists, /removing an old index/i
     end
+
+    class ReplaceIndexSameNameMissingFromDb < TestMigration
+      disable_ddl_transaction!
+
+      def up
+        remove_index :projects, name: "idx_projects_creator", algorithm: :concurrently
+        add_index :projects, :creator_id, name: "idx_projects_creator", algorithm: :concurrently
+      end
+    end
+
+    def test_replace_index_same_name_missing_from_db
+      assert_unsafe ReplaceIndexSameNameMissingFromDb, /removing an old index/i
+    end
   end
 end


### PR DESCRIPTION
Failure mode: The check that catches an unsafe same-name remove→add of an index in one migration only fires if the live connection can resolve the removed index. remove_index records into @removed_indexes only when the index physically exists, and add_index skips the check when that's empty. So a name-only remove_index/add_index pair passes silently whenever the index is missing locally (schema drift), the author never sees it before merge.

This PR Fix: Record every removal (falling back to the migration's declared options when the DB has no match), and match removed-vs-added indexes on name in intersect? the one identifier present in both calls. The check is now driven by the migration's own commands, not DB state.

Notes: Name match is only used in the removed-vs-new comparison, so other callers are unaffected. Legit same-name drop-and-rebuild migrations will now raise (correctly. same no-index window); safety_assured { } is the escape hatch. Added tests for the missing-index regression, distinct-name non-matching, and safety_assured.